### PR TITLE
Setting BulletinPost id with nanoid

### DIFF
--- a/frontend/src/classes/BulletinPost.ts
+++ b/frontend/src/classes/BulletinPost.ts
@@ -1,7 +1,5 @@
-import { Schema } from 'mongoose';
-
 export default class BulletinPost {
-    private _id: Schema.Types.ObjectId;
+    private _id: string;
 
     private _author: string;
   
@@ -13,7 +11,7 @@ export default class BulletinPost {
 
     private _coveyTownID: string;
   
-    constructor(id: Schema.Types.ObjectId, author: string, title: string, text: string, createdAt: Date, coveyTownID: string) {
+    constructor(id: string, author: string, title: string, text: string, createdAt: Date, coveyTownID: string) {
       this._id = id;
       this._author = author;
       if (title.length > 50) {
@@ -30,7 +28,7 @@ export default class BulletinPost {
       this._coveyTownID = coveyTownID
     }
 
-    get id(): Schema.Types.ObjectId {
+    get id(): string {
       return this._id;
     }
   

--- a/services/townService/src/models/posts/dao.ts
+++ b/services/townService/src/models/posts/dao.ts
@@ -1,20 +1,18 @@
-import { Schema } from 'mongoose';
 import PostModel from './model';
 import ServerBulletinPost from '../../types/BulletinPost';
-import { PostCreateRequest } from '../../CoveyTypes';
 
-export async function createPost(post: PostCreateRequest) : Promise<ServerBulletinPost> {
+export async function createPost(post: ServerBulletinPost) : Promise<ServerBulletinPost> {
   const response: ServerBulletinPost = await PostModel.create(post);
   return response;
 } 
 
 // TODO change return type (mongo returns a boolean and number of objects deleted - would need to make a type)?
-export async function deletePost(id: Schema.Types.ObjectId) : Promise<void> {
-  await PostModel.deleteOne({ _id:  id });
+export async function deletePost(id: string) : Promise<void> {
+  await PostModel.deleteOne({ id });
 } 
 
-export async function findPostById(id: Schema.Types.ObjectId) : Promise<ServerBulletinPost | null> {
-  const response: ServerBulletinPost | null = await PostModel.findById(id);
+export async function findPostById(id: string) : Promise<ServerBulletinPost | null> {
+  const response: ServerBulletinPost | null = await PostModel.findOne({ id });
   return response;
 } 
 

--- a/services/townService/src/models/posts/model.ts
+++ b/services/townService/src/models/posts/model.ts
@@ -2,10 +2,12 @@ import { Schema, model, Model } from 'mongoose';
 import ServerBulletinPost from '../../types/BulletinPost';
 
 const PostSchema = new Schema<ServerBulletinPost>({
+  id: { type: String, required: true },
   title: { type: String, required: true },
   text: { type: String, required: true },
   author: { type: String, required: true },
   coveyTownID: { type: String, required: true },
+  createdAt: { type: Date, required: true, default: Date.now },
 }, { collection: 'bulletin_posts' });
 
 const PostModel: Model<ServerBulletinPost> = model<ServerBulletinPost>('BulletinPost', PostSchema);

--- a/services/townService/src/requestHandlers/BulletinPostRequestHandlers.ts
+++ b/services/townService/src/requestHandlers/BulletinPostRequestHandlers.ts
@@ -1,4 +1,3 @@
-import { Schema } from 'mongoose';
 import { createPost, deletePost, findAllPosts, findAllPostsInTown } from '../models/posts/dao';
 import { ResponseEnvelope } from './CoveyTownRequestHandlers';
 import { PostCreateRequest } from '../CoveyTypes';
@@ -23,12 +22,13 @@ export interface PostListResponse {
  * Payload sent by the client to delete a BulletinPost
  */
 export interface PostDeleteRequest {
-  postID: Schema.Types.ObjectId;
+  postID: string;
   coveyTownPassword: string;
 }
 
 export function postCreateHandler(requestData: PostCreateRequest): ResponseEnvelope<PostCreateResponse> {
-  createPost(requestData);
+  const post = new ServerBulletinPost(requestData.author, requestData.title, requestData.text, requestData.coveyTownID);
+  createPost(post);
   return {
     isOK: true,
     response: {

--- a/services/townService/src/types/BulletinPost.ts
+++ b/services/townService/src/types/BulletinPost.ts
@@ -1,7 +1,7 @@
-import { Schema } from 'mongoose';
+import { nanoid } from 'nanoid';
 
 export default class ServerBulletinPost {
-  private _id: Schema.Types.ObjectId;
+  private _id: string;
 
   private _author: string;
 
@@ -13,8 +13,8 @@ export default class ServerBulletinPost {
 
   private _coveyTownID: string;
 
-  constructor(id: Schema.Types.ObjectId, author: string, title: string, text: string, createdAt: Date, coveyTownID: string) {
-    this._id = id;
+  constructor(author: string, title: string, text: string, coveyTownID: string) {
+    this._id = nanoid();
     this._author = author;
     if (title.length > 50) {
       this._title = title.substring(0, 50);
@@ -26,11 +26,11 @@ export default class ServerBulletinPost {
     } else {
       this._text = text;
     }
-    this._createdAt = createdAt;
+    this._createdAt = new Date();
     this._coveyTownID = coveyTownID;
   }
 
-  get id(): Schema.Types.ObjectId {
+  get id(): string {
     return this._id;
   }
 


### PR DESCRIPTION
Changes the BulletinPost's id field from the mongo is to nanoid because we are having issues with mongo in the frontend. Note that the frontend representation of a bulletin post is no longer exactly the same as the backend (constructor is different).